### PR TITLE
update per CRAN reviewer's suggestions

### DIFF
--- a/R/graphMCP.R
+++ b/R/graphMCP.R
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 ## Graph representation in gMCP
 
 #' Class graphMCP
@@ -195,24 +195,24 @@ setMethod("print", "gMCPResult",
 setMethod("show", "gMCPResult",
 		function(object) {
 			# callNextMethod(x, ...)
-			cat("gMCP-Result\n")
-			cat("\nInitial graph:\n")
+			message("gMCP-Result\n")
+		  message("\nInitial graph:\n")
 			print(object@graphs[[1]])
-			cat("\nP-values:\n")
+			message("\nP-values:\n")
 			print(object@pvalues)
 			if (length(object@adjPValues)>0) {
-				cat("\nAdjusted p-values:\n")
+				message("\nAdjusted p-values:\n")
 				print(object@adjPValues)
 			}
-			cat(paste("\nAlpha:",object@alpha,"\n"))
+			message(paste("\nAlpha:",object@alpha,"\n"))
 			if (all(!object@rejected)) {
-				cat("\nNo hypotheses could be rejected.\n")
+			  message("\nNo hypotheses could be rejected.\n")
 			} else {
-				cat("\nHypothesis rejected:\n")
+			  message("\nHypothesis rejected:\n")
 				print(object@rejected)
 			}
 			if (length(object@graphs)>1) {
-				cat("\nFinal graph after", length(object@graphs)-1 ,"steps:\n")
+			  message("\nFinal graph after", length(object@graphs)-1 ,"steps:\n")
 				print(object@graphs[[length(object@graphs)]])
 			}
 		})
@@ -414,31 +414,31 @@ setMethod("show", "graphMCP",
 		function(object) {
 			#callNextMethod(object)
 			nn <- getNodes(object)
-			cat("A graphMCP graph\n")
+			message("A graphMCP graph\n")
 			if (!isTRUE(all.equal(sum(getWeights(object)),1))) {
-				cat(paste("Sum of weight: ",sum(getWeights(object)),"\n", sep=""))
+			  message(paste("Sum of weight: ",sum(getWeights(object)),"\n", sep=""))
 			}
 			for (node in getNodes(object)) {
-				cat(paste(node, " (",ifelse(nodeAttr(object, node, "rejected"),"rejected, ",""),"weight=",format(object@weights[node], digits=4, drop0trailing=TRUE),")\n", sep=""))
+			  message(paste(node, " (",ifelse(nodeAttr(object, node, "rejected"),"rejected, ",""),"weight=",format(object@weights[node], digits=4, drop0trailing=TRUE),")\n", sep=""))
 			}
 			printEdge <- FALSE;
 			for (i in getNodes(object)) {
 				for (j in getNodes(object)) {
 					if (object@m[i,j]!=0) {
 						if (!printEdge) {
-							cat("Edges:\n")
+						  message("Edges:\n")
 							printEdge <- TRUE
 						}
-						cat(paste(i, " -(", object@m[i,j], ")-> ", j, "\n"))
+					  message(paste(i, " -(", object@m[i,j], ")-> ", j, "\n"))
 					}
 				}
 			}
-			if (!printEdge) cat("No edges.\n")
+			if (!printEdge) message("No edges.\n")
 			#if (!is.null(attr(object, "pvalues"))) { # TODO Do we want to have more output here?
-			#  cat("\nAttached p-values: ", attr(object, "pvalues"), "\n")
+			#  message("\nAttached p-values: ", attr(object, "pvalues"), "\n")
 			#}
-			#cat(paste("\nalpha=",paste(format(getWeights(object), digits=4 ,drop0trailing=TRUE),collapse="+"),"=",sum(getWeights(object)),"\n", sep=""))
-			cat("\n")
+			#message(paste("\nalpha=",paste(format(getWeights(object), digits=4 ,drop0trailing=TRUE),collapse="+"),"=",sum(getWeights(object)),"\n", sep=""))
+			message("\n")
 		}
 )
 
@@ -641,19 +641,19 @@ setMethod("print", "gPADInterim",
 
 setMethod("show","gPADInterim",
 		function(object) {
-			cat("Pre-planned graphical MCP at level:",object@alpha,"\n")
+		  message("Pre-planned graphical MCP at level:",object@alpha,"\n")
 			show(object@preplanned)
 			n <- length(object@z1)
-			cat("Proportion of pre-planned measurements\n collected up to interim:\n")
+			message("Proportion of pre-planned measurements\n collected up to interim:\n")
 			v <- object@v
                         if(length(v) == 1) v <- rep(v,n)
 			names(v) <- paste('H',1:n,sep='')
                         print(v)
-			cat("Z-scores computed at interim\n")
+			message("Z-scores computed at interim\n")
 			z1 <- object@z1
 			names(z1) <- paste('H',1:n,sep='')
 			print(z1)
-			cat("\n Interim PCE's by intersection\n")
+			message("\n Interim PCE's by intersection\n")
 			tab <- round(cbind(object@Aj,object@BJ),3)
 			rownames(tab) <- to.intersection(1:nrow(tab))
 			colnames(tab) <- c(paste('A(',1:n,')',sep=''),'BJ')

--- a/R/misc.R
+++ b/R/misc.R
@@ -63,12 +63,12 @@ substituteEps <- function(graph, eps=10^(-3)) {
   # Real function:
   if (is.numeric(graph@m)) return(graph)
   m <- matrix(gsub("\\\\epsilon", eps, graph@m), nrow=length(getNodes(graph)))
-  options(warn=-1)
+
   m2 <- matrix(sapply(m, function(x) {
     result <- try(eval(parse(text=x)), silent=TRUE);
     ifelse(class(result)=="try-error",NA,result)
   }), nrow=length(getNodes(graph)))
-  options(warn=0)
+
   if (all(is.na(m)==is.na(m2))) m <- m2
   rownames(m) <- colnames(m) <- getNodes(graph)
   graph@m <- m
@@ -104,9 +104,6 @@ substituteEps <- function(graph, eps=10^(-3)) {
 #' @examples
 #'
 #' graph <- HungEtWang2010()
-#' \dontrun{
-#' replaceVariables(graph)
-#' }
 #' replaceVariables(graph, list("tau"=0.5,"omega"=0.5, "nu"=0.5))
 #' replaceVariables(graph, list("tau"=c(0.1, 0.5, 0.9),"omega"=c(0.2, 0.8), "nu"=0.4))
 #'
@@ -375,11 +372,6 @@ permutations <- function(n) {
 #' g <- matrix2graph(matrix(0, nrow=6, ncol=6))
 #'
 #' g <- placeNodes(g, nrow=2, force=TRUE)
-#'
-#' \dontrun{
-#' graphGUI(g)
-#'
-#' }
 #'
 #'
 #' @export placeNodes

--- a/man/gMCPLite-package.Rd
+++ b/man/gMCPLite-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A lightweight fork of 'gMCP' with functions for graphical described multiple test procedures. Implement a flexible graph function using 'ggplot2' visualizations to create a multiplicity graph. Contain instructions of multiplicity graph and graphical testing for group sequential design, and necessary unit testing cases using `testthat`.
+A lightweight fork of 'gMCP' with functions for graphical described multiple test procedures. Implements a flexible function using 'ggplot2' to create multiplicity graph visualizations. Contains instructions of multiplicity graph and graphical testing for group sequential design, with necessary unit testing using 'testthat'.
 }
 \seealso{
 Useful links:

--- a/man/placeNodes.Rd
+++ b/man/placeNodes.Rd
@@ -40,11 +40,6 @@ g <- matrix2graph(matrix(0, nrow=6, ncol=6))
 
 g <- placeNodes(g, nrow=2, force=TRUE)
 
-\dontrun{
-graphGUI(g)
-
-}
-
 
 }
 \seealso{

--- a/man/replaceVariables.Rd
+++ b/man/replaceVariables.Rd
@@ -46,9 +46,6 @@ each variable replaced with the specified numeric value.
 \examples{
 
 graph <- HungEtWang2010()
-\dontrun{
-replaceVariables(graph)
-}
 replaceVariables(graph, list("tau"=0.5,"omega"=0.5, "nu"=0.5))
 replaceVariables(graph, list("tau"=c(0.1, 0.5, 0.9),"omega"=c(0.2, 0.8), "nu"=0.4))
 

--- a/vignettes/GraphicalMultiplicity.Rmd
+++ b/vignettes/GraphicalMultiplicity.Rmd
@@ -77,6 +77,11 @@ For group sequential designs, we assume 1-sided testing.
 To reveal code blocks for the remainder of the document, press the code buttons indicated throughout.
 The initial code block sets options and loads needed packages; no modification should be required by the user.
 
+```{r, echo=FALSE}
+# obtain the user's default option
+user_scipen_option <- options()$scipen
+```
+
 ```{r, message=FALSE, warning=FALSE}
 ### THERE SHOULD BE NO NEED TO MODIFY THIS CODE SECTION
 options(scipen = 999)
@@ -643,6 +648,12 @@ for (i in 1:nHypotheses) {
   }
 }
 ```
+
+```{r, echo=FALSE}
+# reset to the user's default option
+options(user_scipen_option)
+```
+
 
 ## Session information
 

--- a/vignettes/GraphicalMultiplicity.Rmd
+++ b/vignettes/GraphicalMultiplicity.Rmd
@@ -77,14 +77,10 @@ For group sequential designs, we assume 1-sided testing.
 To reveal code blocks for the remainder of the document, press the code buttons indicated throughout.
 The initial code block sets options and loads needed packages; no modification should be required by the user.
 
-```{r, echo=FALSE}
-# obtain the user's default option
-user_scipen_option <- options()$scipen
-```
-
 ```{r, message=FALSE, warning=FALSE}
 ### THERE SHOULD BE NO NEED TO MODIFY THIS CODE SECTION
-options(scipen = 999)
+# Prefer fixed notation
+old <- options(scipen = 999)
 # Colorblind palette
 cbPalette <- c("#999999", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
 # 2 packages used for data storage and manipulation: dplyr, tibble
@@ -649,11 +645,10 @@ for (i in 1:nHypotheses) {
 }
 ```
 
-```{r, echo=FALSE}
-# reset to the user's default option
-options(user_scipen_option)
+```{r}
+# Restore default options
+options(old)
 ```
-
 
 ## Session information
 


### PR DESCRIPTION
This PR improved:
1. removed `\dontrun{}` for executable examples.
2. replaced single `cat()` function with `message()` in all R files (ignored in Rmd files, see issue #6 )
3. removed `options(warn=-1)` and `options(warn=0)` since code is redundent
4. added code chunk for obtaining and resetting the user default `scipen` option, for the examples changed it.