### PR TITLE
Add DOI to description, add cran-comments, and update news

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^LICENSES_THIRD_PARTY$
 ^LICENSE$
 ^\.github$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,11 @@ Authors@R: c(
     person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph")
     )
 Description: A lightweight fork of 'gMCP' with functions for graphical
-    described multiple test procedures. Implements a flexible function
-    using 'ggplot2' to create multiplicity graph visualizations.
+    described multiple test procedures introduced in
+    Bretz et al. (2009) <doi:10.1002/sim.3495> and
+    Bretz et al. (2011) <doi:10.1002/bimj.201000239>.
+    Implements a flexible function using 'ggplot2' to create
+    multiplicity graph visualizations.
     Contains instructions of multiplicity graph and graphical testing for
     group sequential design, with necessary unit testing using 'testthat'.
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gMCPLite
 Title: Lightweight Graph Based Multiple Comparison Procedures
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Yalin", "Zhu", email = "yalin.zhu@merck.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3830-8660")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# gMCPLite 0.1.1
+
+## Improvements
+
+- Added method references DOI to the description field of the `DESCRIPTION` file.
+- Removed redundant `\dontrun{}` from examples.
+- Replaced `cat()` with `message()` where suppression options like `verbose` are
+  not available, except for printing raw R Markdown content in vignettes,
+  which requires `cat()`.
+- Removed setting `options(warn=-1)` and `options(warn=0)` in function.
+- Reset the user's `options()` in vignettes after changing it.
+
 # gMCPLite 0.1.0
 
 - Created a fork from gMCP 0.8-15 and removed Java dependencies.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,13 @@
+This is a new release that fixed the issues in v0.1.0 identified by CRAN.
+
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+## Improvements
+
+ * Added method references DOI to the description field of the DESCRIPTION file.
+ * Removed redundant \dontrun{} from examples.
+ * Replaced cat() with message() where suppression options like verbose are not available, except for printing raw R Markdown content in vignettes, which requires cat().
+ * Removed setting options(warn=-1) and options(warn=0) in function.
+ * Reset the user's options() in vignettes after changing it.

--- a/man/gMCPLite-package.Rd
+++ b/man/gMCPLite-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A lightweight fork of 'gMCP' with functions for graphical described multiple test procedures. Implements a flexible function using 'ggplot2' to create multiplicity graph visualizations. Contains instructions of multiplicity graph and graphical testing for group sequential design, with necessary unit testing using 'testthat'.
+A lightweight fork of 'gMCP' with functions for graphical described multiple test procedures introduced in Bretz et al. (2009) \doi{10.1002/sim.3495} and Bretz et al. (2011) \doi{10.1002/bimj.201000239}. Implements a flexible function using 'ggplot2' to create multiplicity graph visualizations. Contains instructions of multiplicity graph and graphical testing for group sequential design, with necessary unit testing using 'testthat'.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
- Add method references DOI to description field in DESCRIPTION.
- Add `cran-comments.md` with content one can use to paste into the optional comments box when submitting to CRAN.
- Update news to document the changes.
- Bump version number to 0.1.1