### PR TITLE
Fix Unicode conversion errors when `pdf()` is used for running code examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gMCPLite
 Title: Lightweight Graph Based Multiple Comparison Procedures
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
     person("Yalin", "Zhu", email = "yalin.zhu@outlook.com", role = "aut",
            comment = c(ORCID = "0000-0003-3830-8660")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# gMCPLite 0.1.4
+
+- Use the `cairo_pdf()` device for better Unicode character plotting support
+  in code examples when the `pdf()` device is intentionally used, for example,
+  when running `R CMD check` on the package (#22).
+
 # gMCPLite 0.1.3
 
 - Fix pkgdown vignette rendering of dynamic tabsets (#16).

--- a/R/hgraph.R
+++ b/R/hgraph.R
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 #' Create multiplicity graphs using ggplot2
 #'
 #' Plots a multiplicity graph defined by user inputs.
@@ -52,6 +52,17 @@
 #' @return A `ggplot` object with a multi-layer multiplicity graph
 #'
 #' @examples
+#' # Use Cairo PDF device for better Unicode character support
+#' # when checking the package. Needed for R >= 4.4.0.
+#' if (names(dev.cur()) == "pdf") {
+#'   fn <- attr(.Device, "filepath")
+#'   fn0 <- "gMCPLite-Ex.pdf"
+#'   if (!is.null(fn) && fn == fn0) {
+#'     dv <- cairo_pdf(fn0)
+#'     on.exit(dev.off(dv), add = TRUE)
+#'   }
+#' }
+#'
 #' # Defaults: note clockwise ordering
 #' hGraph(5)
 #' # Add colors (default is 3 gray shades)

--- a/man/hGraph.Rd
+++ b/man/hGraph.Rd
@@ -109,6 +109,17 @@ See vignette **Multiplicity graphs formatting using ggplot2**
 for explanation of formatting.
 }
 \examples{
+# Use Cairo PDF device for better Unicode character support
+# when checking the package. Needed for R >= 4.4.0.
+if (names(dev.cur()) == "pdf") {
+  fn <- attr(.Device, "filepath")
+  fn0 <- "gMCPLite-Ex.pdf"
+  if (!is.null(fn) && fn == fn0) {
+    dv <- cairo_pdf(fn0)
+    on.exit(dev.off(dv), add = TRUE)
+  }
+}
+
 # Defaults: note clockwise ordering
 hGraph(5)
 # Add colors (default is 3 gray shades)


### PR DESCRIPTION
Fixes #22.

This PR adds a condition in the `hGraph()` code examples to use the `cairo_pdf()` device and avoid the Unicode conversion errors in R >= 4.4.0.

The condition is set to be conservative as it tries to only apply this change to the situation where the `hGraph()` code examples are ran by `R CMD check` - where the `pdf()` device is explicitly used to produce a PDF of the plots (see how R does this in [examples-header.R](https://github.com/wch/r-source/blob/4e46b41d4b5242b16c3086345bf637212cb8ffa0/share/R/examples-header.R#L84)).