### PR TITLE
Name `guide` argument in `hGraph()`

### DIFF
--- a/R/hgraph.R
+++ b/R/hgraph.R
@@ -309,7 +309,7 @@ hGraph <- function(
     #   scale_alpha(guide="none") +
     scale_fill_manual(values=palette,
                       labels=labels,
-                      guide_legend(legend.name)) +
+                      guide = guide_legend(legend.name)) +
     theme(legend.position = legend.position,
           legend.title = ggplot2::element_text(size = legend.textsize),
           legend.text = ggplot2::element_text(size = legend.textsize)) +


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break gMCPLite. The culprit of the breakage is that we have made the `name` argument of scales the first, see https://github.com/tidyverse/ggplot2/pull/5583.  

Because `hGraph()` passes the legend as an unnamed argument, this gets matched by position to the `name` argument in the new version of ggplot2. This PR names the guide argument to prevent it being passed to the wrong argument.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled at the end of January / early Februari. The progress can be tracked in https://github.com/tidyverse/ggplot2/issues/5588.
