### PR TITLE
Remove invalid URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Suggests:
     testthat (>= 3.0.0),
     tibble
 Config/testthat/edition: 3
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/exampleGraphs.R
+++ b/R/exampleGraphs.R
@@ -83,7 +83,6 @@
 #' Bretz, F., Maurer, W., Brannath, W., Posch, M.: A graphical approach to
 #' sequentially rejective multiple test procedures. Statistics in Medicine 2009
 #' vol. 28 issue 4 page 586-604.
-#' \url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 #'
 #' Bretz, F., Maurer, W. and Hommel, G. (2011), Test and power considerations
 #' for multiple endpoint analyses using sequentially rejective graphical
@@ -448,7 +447,7 @@ improvedParallelGatekeeping <- function() {
 	edgeAttr(graph, "H4", "H2", "labelY") <- 200
 	attr(graph, "description") <- paste("Graph representing an improved parallel gatekeeping procedure",
 			"",
-			"Literature: Bretz, F., Maurer, W., Brannath, W., Posch, M.: A graphical approach to sequentially rejective multiple test procedures. Statistics in Medicine 2009 vol. 28 issue 4 page 586-604. URL: https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf .", sep="\n")
+			"Literature: Bretz, F., Maurer, W., Brannath, W., Posch, M.: A graphical approach to sequentially rejective multiple test procedures. Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.", sep="\n")
 	return(graph)
 }
 

--- a/R/gMCP.R
+++ b/R/gMCP.R
@@ -108,7 +108,6 @@
 #' @references Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 #' graphical approach to sequentially rejective multiple test procedures.
 #' Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-#' \url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 #'
 #' Bretz F., Posch M., Glimm E., Klinglmueller F., Maurer W., Rohmeyer K.
 #' (2011): Graphical approaches for multiple endpoint problems using weighted
@@ -438,7 +437,7 @@ adjPValues <- function(graph, pvalues, upscale=FALSE, verbose=FALSE) {
 #' @references Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 #' graphical approach to sequentially rejective multiple test procedures.
 #' Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-#' \url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
+#'
 #' @keywords htest graphs
 #'
 #' @export rejectNode

--- a/R/gMCP.extended.R
+++ b/R/gMCP.extended.R
@@ -362,7 +362,6 @@ simes.test <- function(pvalues, weights, alpha=0.05, adjPValues=TRUE, verbose=FA
 #' @references Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 #' graphical approach to sequentially rejective multiple test procedures.
 #' Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-#' \url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 #'
 #' Bretz F., Posch M., Glimm E., Klinglmueller F., Maurer W., Rohmeyer K.
 #' (2011): Graphical approaches for multiple endpoint problems using weighted

--- a/R/graphMCP.R
+++ b/R/graphMCP.R
@@ -514,7 +514,6 @@ setMethod("plot", "graphMCP",
 #' @references Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 #' graphical approach to sequentially rejective multiple test procedures.
 #' Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-#' \url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 #'
 #' @keywords htest graphs
 #'

--- a/man/exampleGraphs.Rd
+++ b/man/exampleGraphs.Rd
@@ -169,7 +169,6 @@ Statistics in Medicine. 22, 2387-2400.
 Bretz, F., Maurer, W., Brannath, W., Posch, M.: A graphical approach to
 sequentially rejective multiple test procedures. Statistics in Medicine 2009
 vol. 28 issue 4 page 586-604.
-\url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 
 Bretz, F., Maurer, W. and Hommel, G. (2011), Test and power considerations
 for multiple endpoint analyses using sequentially rejective graphical

--- a/man/gMCP.Rd
+++ b/man/gMCP.Rd
@@ -139,7 +139,6 @@ gMCP(g2, pvalues=c(0.01, 0.02, 0.04, 0.04, 0.7), upscale=TRUE)
 Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 graphical approach to sequentially rejective multiple test procedures.
 Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-\url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 
 Bretz F., Posch M., Glimm E., Klinglmueller F., Maurer W., Rohmeyer K.
 (2011): Graphical approaches for multiple endpoint problems using weighted

--- a/man/gMCP.extended.Rd
+++ b/man/gMCP.extended.Rd
@@ -87,7 +87,6 @@ gMCP(g3, pvalues=c(0.01, 0.02, 0.04, 0.04, 0.7), correlation=diag(5))
 Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 graphical approach to sequentially rejective multiple test procedures.
 Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-\url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 
 Bretz F., Posch M., Glimm E., Klinglmueller F., Maurer W., Rohmeyer K.
 (2011): Graphical approaches for multiple endpoint problems using weighted

--- a/man/rejectNode.Rd
+++ b/man/rejectNode.Rd
@@ -47,7 +47,6 @@ rejectNode(graph = g, node = 4)
 Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 graphical approach to sequentially rejective multiple test procedures.
 Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-\url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 }
 \seealso{
 \code{graphMCP}

--- a/man/simConfint.Rd
+++ b/man/simConfint.Rd
@@ -78,7 +78,6 @@ ci
 Frank Bretz, Willi Maurer, Werner Brannath, Martin Posch: A
 graphical approach to sequentially rejective multiple test procedures.
 Statistics in Medicine 2009 vol. 28 issue 4 page 586-604.
-\url{https://www.meduniwien.ac.at/fwf_adaptive/papers/bretz_2009_22.pdf}
 }
 \seealso{
 \code{\link{graphMCP}}


### PR DESCRIPTION
This PR removes the paper PDF URL that is now a 404 page.

This fixes the `R CMD check --as-cran` warning.