### PR TITLE
Add visual regression tests for `hGraph()`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.github$
 ^cran-comments\.md$
 ^docs$
+tests/testthat/_snaps$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Suggests:
     rmarkdown,
     scales,
     testthat (>= 3.0.0),
-    tibble
+    tibble,
+    vdiffr
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2

--- a/tests/testthat/_snaps/hgraph/alpha-allocation-hypotheses-names-transitions.svg
+++ b/tests/testthat/_snaps/hgraph/alpha-allocation-hypotheses-names-transitions.svg
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='178.90,106.02 178.35,98.24 176.69,90.57 173.96,83.14 170.20,76.05 165.45,69.42 159.81,63.34 153.34,57.91 146.15,53.21 138.35,49.31 130.06,46.27 121.39,44.14 112.49,42.94 103.49,42.70 94.52,43.42 85.72,45.09 77.23,47.68 69.17,51.16 61.66,55.47 54.82,60.54 48.75,66.30 43.55,72.67 39.28,79.54 36.03,86.82 33.83,94.38 32.73,102.12 32.73,109.92 33.83,117.66 36.03,125.23 39.28,132.50 43.55,139.37 48.75,145.74 54.82,151.50 61.66,156.58 69.17,160.89 77.23,164.36 85.72,166.95 94.52,168.62 103.49,169.34 112.49,169.10 121.39,167.91 130.06,165.77 138.35,162.73 146.15,158.83 153.34,154.13 159.81,148.70 165.45,142.62 170.20,135.99 173.96,128.91 176.69,121.47 178.35,113.81 178.90,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,106.02 686.72,98.24 685.06,90.57 682.33,83.14 678.57,76.05 673.83,69.42 668.18,63.34 661.71,57.91 654.53,53.21 646.73,49.31 638.43,46.27 629.77,44.14 620.87,42.94 611.86,42.70 602.90,43.42 594.10,45.09 585.60,47.68 577.54,51.16 570.03,55.47 563.19,60.54 557.12,66.30 551.92,72.67 547.66,79.54 544.40,86.82 542.21,94.38 541.10,102.12 541.10,109.92 542.21,117.66 544.40,125.23 547.66,132.50 551.92,139.37 557.12,145.74 563.19,151.50 570.03,156.58 577.54,160.89 585.60,164.36 594.10,166.95 602.90,168.62 611.86,169.34 620.87,169.10 629.77,167.91 638.43,165.77 646.73,162.73 654.53,158.83 661.71,154.13 668.18,148.70 673.83,142.62 678.57,135.99 682.33,128.91 685.06,121.47 686.72,113.81 687.27,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='433.09,487.28 432.53,479.50 430.88,471.83 428.15,464.40 424.38,457.31 419.64,450.68 413.99,444.60 407.53,439.17 400.34,434.47 392.54,430.57 384.24,427.53 375.58,425.40 366.68,424.20 357.68,423.96 348.71,424.68 339.91,426.35 331.42,428.94 323.35,432.42 315.84,436.73 309.00,441.80 302.94,447.57 297.73,453.93 293.47,460.80 290.22,468.08 288.02,475.64 286.91,483.38 286.91,491.18 288.02,498.92 290.22,506.49 293.47,513.76 297.73,520.63 302.94,527.00 309.00,532.76 315.84,537.84 323.35,542.15 331.42,545.62 339.91,548.22 348.71,549.89 357.68,550.60 366.68,550.36 375.58,549.17 384.24,547.03 392.54,543.99 400.34,540.09 407.53,535.39 413.99,529.96 419.64,523.89 424.38,517.25 428.15,510.17 430.88,502.74 432.53,495.07 433.09,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='105.74' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='37.95px' lengthAdjust='spacingAndGlyphs'>ORR</text>
+<text x='105.74' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.005</text>
+<text x='614.12' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='33.21px' lengthAdjust='spacingAndGlyphs'>PFS</text>
+<text x='614.12' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.007</text>
+<text x='359.93' y='480.87' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='24.68px' lengthAdjust='spacingAndGlyphs'>OS</text>
+<text x='359.93' y='505.45' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.013</text>
+<line x1='308.05' y1='442.35' x2='124.74' y2='167.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='134.75,172.35 124.74,167.40 125.46,178.55 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='176.62' y1='89.57' x2='543.24' y2='89.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='533.56,95.16 543.24,89.57 533.56,83.99 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='595.13' y1='167.40' x2='411.82' y2='442.35' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='412.54,431.20 411.82,442.35 421.83,437.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='232.27' y='341.17' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='284.15' y='80.04' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='519.35' y='249.52' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='246.94' y='354.62' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='298.83' y='93.49' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='534.02' y='262.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='270.07px' lengthAdjust='spacingAndGlyphs'>alpha allocation hypotheses names transitions</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/hgraph/alpha-digits.svg
+++ b/tests/testthat/_snaps/hgraph/alpha-digits.svg
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='496.87,106.02 495.83,98.24 492.73,90.57 487.62,83.14 480.57,76.05 471.69,69.42 461.11,63.34 449.00,57.91 435.54,53.21 420.94,49.31 405.40,46.27 389.18,44.14 372.51,42.94 355.65,42.70 338.86,43.42 322.38,45.09 306.47,47.68 291.37,51.16 277.31,55.47 264.50,60.54 253.14,66.30 243.39,72.67 235.41,79.54 229.32,86.82 225.20,94.38 223.13,102.12 223.13,109.92 225.20,117.66 229.32,125.23 235.41,132.50 243.39,139.37 253.14,145.74 264.50,151.50 277.31,156.58 291.37,160.89 306.47,164.36 322.38,166.95 338.86,168.62 355.65,169.34 372.51,169.10 389.18,167.91 405.40,165.77 420.94,162.73 435.54,158.83 449.00,154.13 461.11,148.70 471.69,142.62 480.57,135.99 487.62,128.91 492.73,121.47 495.83,113.81 496.87,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,487.28 686.23,479.50 683.13,471.83 678.02,464.40 670.97,457.31 662.09,450.68 651.52,444.60 639.41,439.17 625.95,434.47 611.34,430.57 595.81,427.53 579.58,425.40 562.92,424.20 546.06,423.96 529.26,424.68 512.78,426.35 496.87,428.94 481.78,432.42 467.71,436.73 454.91,441.80 443.54,447.57 433.80,453.93 425.82,460.80 419.72,468.08 415.61,475.64 413.54,483.38 413.54,491.18 415.61,498.92 419.72,506.49 425.82,513.76 433.80,520.63 443.54,527.00 454.91,532.76 467.71,537.84 481.78,542.15 496.87,545.62 512.78,548.22 529.26,549.89 546.06,550.60 562.92,550.36 579.58,549.17 595.81,547.03 611.34,543.99 625.95,540.09 639.41,535.39 651.52,529.96 662.09,523.89 670.97,517.25 678.02,510.17 683.13,502.74 686.23,495.07 687.27,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='306.46,487.28 305.43,479.50 302.33,471.83 297.21,464.40 290.16,457.31 281.28,450.68 270.71,444.60 258.60,439.17 245.14,434.47 230.53,430.57 215.00,427.53 198.77,425.40 182.11,424.20 165.25,423.96 148.45,424.68 131.97,426.35 116.07,428.94 100.97,432.42 86.91,436.73 74.10,441.80 62.73,447.57 52.99,453.93 45.01,460.80 38.91,468.08 34.80,475.64 32.73,483.38 32.73,491.18 34.80,498.92 38.91,506.49 45.01,513.76 52.99,520.63 62.73,527.00 74.10,532.76 86.91,537.84 100.97,542.15 116.07,545.62 131.97,548.22 148.45,549.89 165.25,550.60 182.11,550.36 198.77,549.17 215.00,547.03 230.53,543.99 245.14,540.09 258.60,535.39 270.71,529.96 281.28,523.89 290.16,517.25 297.21,510.17 302.33,502.74 305.43,495.07 306.46,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='359.87' y='100.67' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='18.19px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='359.87' y='121.16' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='52.15px' lengthAdjust='spacingAndGlyphs'>α=0.008</text>
+<text x='550.27' y='481.94' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='18.19px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='550.27' y='502.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='52.15px' lengthAdjust='spacingAndGlyphs'>α=0.008</text>
+<text x='169.47' y='481.94' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='18.19px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='169.47' y='502.42' text-anchor='middle' style='font-size: 14.23px; font-family: sans;' textLength='52.15px' lengthAdjust='spacingAndGlyphs'>α=0.008</text>
+<line x1='498.79' y1='428.37' x2='369.46' y2='169.41' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='383.45,178.65 369.46,169.41 368.45,186.14 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='179.06' y1='423.89' x2='308.39' y2='164.94' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='309.40,181.67 308.39,164.94 294.40,174.18 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='411.35' y1='164.94' x2='540.68' y2='423.89' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='526.70,414.65 540.68,423.89 541.69,407.16 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='305.19' y1='477.34' x2='414.55' y2='477.34' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='400.04,485.72 414.55,477.34 400.04,468.96 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='350.28' y1='169.41' x2='220.95' y2='428.37' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='219.94,411.64 220.95,428.37 234.93,419.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='414.55' y1='497.22' x2='305.19' y2='497.22' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='319.70,488.84 305.19,497.22 319.70,505.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='428.20' y='332.52' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='194.69' y='328.04' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='426.98' y='241.72' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='314.16' y='467.81' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='279.68' y='246.20' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='350.62' y='487.69' width='54.97' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='455.68' y='345.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='222.17' y='341.49' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='454.46' y='255.17' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='341.64' y='481.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='307.17' y='259.65' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='378.10' y='501.14' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='66.78px' lengthAdjust='spacingAndGlyphs'>alpha digits</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/hgraph/basic-layout.svg
+++ b/tests/testthat/_snaps/hgraph/basic-layout.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='203.20,108.86 202.55,100.73 200.62,92.72 197.43,84.95 193.04,77.55 187.51,70.62 180.93,64.27 173.39,58.59 165.01,53.68 155.91,49.61 146.24,46.43 136.13,44.20 125.75,42.95 115.25,42.70 104.79,43.45 94.53,45.19 84.63,47.90 75.22,51.54 66.47,56.04 58.49,61.34 51.41,67.36 45.34,74.02 40.37,81.20 36.58,88.79 34.02,96.70 32.73,104.79 32.73,112.94 34.02,121.02 36.58,128.93 40.37,136.53 45.34,143.71 51.41,150.36 58.49,156.38 66.47,161.69 75.22,166.19 84.63,169.82 94.53,172.53 104.79,174.27 115.25,175.02 125.75,174.77 136.13,173.52 146.24,171.29 155.91,168.12 165.01,164.04 173.39,159.13 180.93,153.46 187.51,147.11 193.04,140.18 197.43,132.77 200.62,125.01 202.55,117.00 203.20,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,108.86 686.63,100.73 684.70,92.72 681.51,84.95 677.12,77.55 671.59,70.62 665.01,64.27 657.47,58.59 649.08,53.68 639.99,49.61 630.31,46.43 620.21,44.20 609.83,42.95 599.33,42.70 588.87,43.45 578.61,45.19 568.70,47.90 559.30,51.54 550.54,56.04 542.57,61.34 535.49,67.36 529.42,74.02 524.45,81.20 520.66,88.79 518.09,96.70 516.80,104.79 516.80,112.94 518.09,121.02 520.66,128.93 524.45,136.53 529.42,143.71 535.49,150.36 542.57,156.38 550.54,161.69 559.30,166.19 568.70,169.82 578.61,172.53 588.87,174.27 599.33,175.02 609.83,174.77 620.21,173.52 630.31,171.29 639.99,168.12 649.08,164.04 657.47,159.13 665.01,153.46 671.59,147.11 677.12,140.18 681.51,132.77 684.70,125.01 686.63,117.00 687.27,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,484.44 686.63,476.31 684.70,468.30 681.51,460.53 677.12,453.13 671.59,446.20 665.01,439.85 657.47,434.17 649.08,429.26 639.99,425.19 630.31,422.01 620.21,419.78 609.83,418.53 599.33,418.28 588.87,419.03 578.61,420.78 568.70,423.48 559.30,427.12 550.54,431.62 542.57,436.92 535.49,442.94 529.42,449.60 524.45,456.78 520.66,464.38 518.09,472.28 516.80,480.37 516.80,488.52 518.09,496.61 520.66,504.51 524.45,512.11 529.42,519.29 535.49,525.94 542.57,531.96 550.54,537.27 559.30,541.77 568.70,545.40 578.61,548.11 588.87,549.85 599.33,550.60 609.83,550.35 620.21,549.10 630.31,546.87 639.99,543.70 649.08,539.62 657.47,534.71 665.01,529.04 671.59,522.69 677.12,515.76 681.51,508.35 684.70,500.59 686.63,492.58 687.27,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='203.20,484.44 202.55,476.31 200.62,468.30 197.43,460.53 193.04,453.13 187.51,446.20 180.93,439.85 173.39,434.17 165.01,429.26 155.91,425.19 146.24,422.01 136.13,419.78 125.75,418.53 115.25,418.28 104.79,419.03 94.53,420.78 84.63,423.48 75.22,427.12 66.47,431.62 58.49,436.92 51.41,442.94 45.34,449.60 40.37,456.78 36.58,464.38 34.02,472.28 32.73,480.37 32.73,488.52 34.02,496.61 36.58,504.51 40.37,512.11 45.34,519.29 51.41,525.94 58.49,531.96 66.47,537.27 75.22,541.77 84.63,545.40 94.53,548.11 104.79,549.85 115.25,550.60 125.75,550.35 136.13,549.10 146.24,546.87 155.91,543.70 165.01,539.62 173.39,534.71 180.93,529.04 187.51,522.69 193.04,515.76 197.43,508.35 200.62,500.59 202.55,492.58 203.20,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='117.88' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='117.88' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<text x='601.96' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='601.96' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<text x='601.96' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='601.96' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<text x='117.88' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H4</text>
+<text x='117.88' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<line x1='530.81' y1='447.56' x2='165.42' y2='164.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='176.49,165.58 165.42,164.07 169.64,174.41 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='101.19' y1='419.32' x2='101.19' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='106.77,183.66 101.19,173.98 95.60,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='121.81' x2='201.81' y2='121.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,116.23 201.81,121.81 211.49,127.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='201.81' y1='95.91' x2='518.03' y2='95.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,101.50 518.03,95.91 508.35,90.32 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='585.26' y1='419.32' x2='585.26' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='590.85,183.66 585.26,173.98 579.68,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='165.42' y1='429.24' x2='530.81' y2='145.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='526.58,156.09 530.81,145.75 519.74,147.27 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='189.03' y1='145.75' x2='554.42' y2='429.24' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='543.35,427.72 554.42,429.24 550.19,418.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='201.81' y1='471.49' x2='518.03' y2='471.49' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,477.08 518.03,471.49 508.35,465.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='618.65' y1='173.98' x2='618.65' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='613.07,409.65 618.65,419.32 624.24,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='134.58' y1='173.98' x2='134.58' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='128.99,409.65 134.58,419.32 140.16,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='554.42' y1='164.07' x2='189.03' y2='447.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='193.25,437.21 189.03,447.56 200.10,446.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='497.40' x2='201.81' y2='497.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,491.81 201.81,497.40 211.49,502.98 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='391.90' y='343.10' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='84.07' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='111.86' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='290.10' y='85.95' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='568.15' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='270.10' y='324.78' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='293.71' y='230.29' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='290.10' y='461.53' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='601.54' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='117.46' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='415.51' y='248.60' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='487.44' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='409.01' y='356.98' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='101.19' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='125.73' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='307.22' y='99.82' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='585.26' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='287.22' y='338.66' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='310.83' y='244.16' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='307.22' y='475.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='618.65' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='134.58' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='432.62' y='262.48' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='501.31' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='69.72px' lengthAdjust='spacingAndGlyphs'>basic layout</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/hgraph/clockwise-order.svg
+++ b/tests/testthat/_snaps/hgraph/clockwise-order.svg
@@ -1,0 +1,127 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='267.61,97.54 267.10,90.80 265.56,84.16 263.02,77.72 259.52,71.58 255.12,65.84 249.87,60.58 243.86,55.87 237.18,51.80 229.94,48.43 222.23,45.79 214.18,43.94 205.91,42.91 197.55,42.70 189.21,43.32 181.04,44.77 173.14,47.01 165.65,50.02 158.68,53.76 152.32,58.15 146.68,63.14 141.85,68.66 137.89,74.61 134.87,80.91 132.82,87.46 131.80,94.16 131.80,100.92 132.82,107.62 134.87,114.17 137.89,120.47 141.85,126.42 146.68,131.94 152.32,136.93 158.68,141.33 165.65,145.06 173.14,148.07 181.04,150.31 189.21,151.76 197.55,152.38 205.91,152.17 214.18,151.14 222.23,149.29 229.94,146.66 237.18,143.28 243.86,139.21 249.87,134.50 255.12,129.24 259.52,123.50 263.02,117.36 265.56,110.92 267.10,104.28 267.61,97.54 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='588.20,97.54 587.69,90.80 586.15,84.16 583.61,77.72 580.12,71.58 575.71,65.84 570.46,60.58 564.46,55.87 557.78,51.80 550.53,48.43 542.82,45.79 534.77,43.94 526.50,42.91 518.14,42.70 509.81,43.32 501.63,44.77 493.74,47.01 486.25,50.02 479.27,53.76 472.91,58.15 467.28,63.14 462.44,68.66 458.48,74.61 455.46,80.91 453.42,87.46 452.39,94.16 452.39,100.92 453.42,107.62 455.46,114.17 458.48,120.47 462.44,126.42 467.28,131.94 472.91,136.93 479.27,141.33 486.25,145.06 493.74,148.07 501.63,150.31 509.81,151.76 518.14,152.38 526.50,152.17 534.77,151.14 542.82,149.29 550.53,146.66 557.78,143.28 564.46,139.21 570.46,134.50 575.71,129.24 580.12,123.50 583.61,117.36 586.15,110.92 587.69,104.28 588.20,97.54 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,343.66 686.76,336.91 685.22,330.27 682.68,323.84 679.18,317.70 674.78,311.96 669.53,306.69 663.52,301.99 656.85,297.92 649.60,294.54 641.89,291.91 633.84,290.06 625.57,289.02 617.21,288.81 608.87,289.44 600.70,290.88 592.81,293.13 585.31,296.14 578.34,299.87 571.98,304.27 566.34,309.26 561.51,314.77 557.55,320.72 554.53,327.02 552.49,333.57 551.46,340.28 551.46,347.03 552.49,353.74 554.53,360.29 557.55,366.59 561.51,372.54 566.34,378.05 571.98,383.05 578.34,387.44 585.31,391.17 592.81,394.18 600.70,396.43 608.87,397.87 617.21,398.50 625.57,398.29 633.84,397.25 641.89,395.40 649.60,392.77 656.85,389.39 663.52,385.32 669.53,380.62 674.78,375.36 679.18,369.61 682.68,363.48 685.22,357.04 686.76,350.40 687.27,343.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='427.91,495.76 427.39,489.02 425.85,482.38 423.32,475.94 419.82,469.81 415.41,464.06 410.17,458.80 404.16,454.10 397.48,450.03 390.23,446.65 382.53,444.02 374.48,442.17 366.21,441.13 357.84,440.92 349.51,441.55 341.33,442.99 333.44,445.24 325.95,448.25 318.97,451.98 312.62,456.37 306.98,461.37 302.14,466.88 298.19,472.83 295.16,479.13 293.12,485.68 292.09,492.39 292.09,499.14 293.12,505.85 295.16,512.40 298.19,518.70 302.14,524.65 306.98,530.16 312.62,535.15 318.97,539.55 325.95,543.28 333.44,546.29 341.33,548.54 349.51,549.98 357.84,550.60 366.21,550.40 374.48,549.36 382.53,547.51 390.23,544.88 397.48,541.50 404.16,537.43 410.17,532.73 415.41,527.46 419.82,521.72 423.32,515.58 425.85,509.15 427.39,502.51 427.91,495.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='168.54,343.66 168.03,336.91 166.49,330.27 163.95,323.84 160.46,317.70 156.05,311.96 150.80,306.69 144.79,301.99 138.12,297.92 130.87,294.54 123.16,291.91 115.11,290.06 106.84,289.02 98.48,288.81 90.14,289.44 81.97,290.88 74.08,293.13 66.58,296.14 59.61,299.87 53.25,304.27 47.61,309.26 42.78,314.77 38.82,320.72 35.80,327.02 33.76,333.57 32.73,340.28 32.73,347.03 33.76,353.74 35.80,360.29 38.82,366.59 42.78,372.54 47.61,378.05 53.25,383.05 59.61,387.44 66.58,391.17 74.08,394.18 81.97,396.43 90.14,397.87 98.48,398.50 106.84,398.29 115.11,397.25 123.16,395.40 130.87,392.77 138.12,389.39 144.79,385.32 150.80,380.62 156.05,375.36 160.46,369.61 163.95,363.48 166.49,357.04 168.03,350.40 168.54,343.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<text x='199.64' y='91.12' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='199.64' y='115.71' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.005</text>
+<text x='520.23' y='91.12' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='520.23' y='115.71' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.005</text>
+<text x='619.30' y='337.24' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='619.30' y='361.82' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.005</text>
+<text x='359.94' y='489.35' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H4</text>
+<text x='359.94' y='513.93' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.005</text>
+<text x='100.57' y='337.24' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H5</text>
+<text x='100.57' y='361.82' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='62.57px' lengthAdjust='spacingAndGlyphs'>α=0.005</text>
+<line x1='452.89' y1='106.15' x2='266.98' y2='106.15' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='276.65,100.56 266.98,106.15 276.65,111.74 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='111.24' y1='289.30' x2='168.69' y2='146.58' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='170.26,157.64 168.69,146.58 159.89,153.47 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='328.98' y1='446.73' x2='210.30' y2='151.90' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='219.10,158.79 210.30,151.90 208.74,162.96 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='558.55' y1='318.67' x2='247.85' y2='136.45' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='259.02,136.53 247.85,136.45 253.37,146.17 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='266.98' y1='88.93' x2='452.89' y2='88.93' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='443.22,94.52 452.89,88.93 443.22,83.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='148.78' y1='304.74' x2='459.48' y2='122.52' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='453.96,132.24 459.48,122.52 448.31,122.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='370.60' y1='441.41' x2='489.28' y2='146.58' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='490.85,157.64 489.28,146.58 480.48,153.47 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='588.35' y1='294.62' x2='530.90' y2='151.90' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='539.69,158.79 530.90,151.90 529.33,162.96 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='260.39' y1='122.52' x2='571.09' y2='304.74' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='559.92,304.67 571.09,304.74 565.57,295.03 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='167.91' y1='335.05' x2='551.96' y2='335.05' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='542.28,340.63 551.96,335.05 542.28,329.46 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='408.14' y1='456.85' x2='558.55' y2='368.64' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='553.03,378.36 558.55,368.64 547.38,368.72 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='551.18' y1='146.58' x2='608.63' y2='289.30' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='599.84,282.41 608.63,289.30 610.20,278.24 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='571.09' y1='382.57' x2='420.68' y2='470.78' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='426.20,461.06 420.68,470.78 431.86,470.70 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='230.59' y1='146.58' x2='349.27' y2='441.41' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='340.47,434.52 349.27,441.41 350.84,430.34 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='161.32' y1='368.64' x2='311.73' y2='456.85' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='300.55,456.77 311.73,456.85 306.21,447.13 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='509.57' y1='151.90' x2='390.89' y2='446.73' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='389.32,435.67 390.89,446.73 399.68,439.84 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='299.19' y1='470.78' x2='148.78' y2='382.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='159.95,382.65 148.78,382.57 154.30,392.28 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='551.96' y1='352.26' x2='167.91' y2='352.26' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='177.59,346.68 167.91,352.26 177.59,357.85 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='188.97' y1='151.90' x2='131.52' y2='294.62' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='129.95,283.56 131.52,294.62 140.32,287.73 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='472.02' y1='136.45' x2='161.32' y2='318.67' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='166.84,308.96 161.32,318.67 172.49,318.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='377.29' y='97.89' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='116.75' y='233.47' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='275.79' y='340.20' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='441.35' y='249.68' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='315.31' y='80.68' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='238.71' y='235.75' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='396.52' y='334.88' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='555.56' y='238.79' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='350.32' y='175.01' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='282.29' y='326.79' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='444.65' y='419.19' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='556.70' y='185.90' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='507.32' y='403.72' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='256.52' y='236.60' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='197.82' y='389.79' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='456.37' y='241.92' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='235.42' y='433.12' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='410.31' y='344.01' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='156.19' y='191.22' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='354.82' y='188.94' width='27.27' height='16.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='390.92' y='110.07' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='130.39' y='245.64' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='289.42' y='352.37' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='454.98' y='261.85' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='328.95' y='92.85' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='252.35' y='247.92' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='410.16' y='347.05' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='569.20' y='250.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='363.95' y='187.18' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='295.93' y='338.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='458.28' y='431.36' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='570.33' y='198.07' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='520.96' y='415.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='270.15' y='248.77' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='211.45' y='401.96' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='470.01' y='254.09' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='249.05' y='445.29' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='423.94' y='356.18' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='169.82' y='203.39' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='368.45' y='201.11' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='90.98px' lengthAdjust='spacingAndGlyphs'>clockwise order</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/hgraph/custom-ellipses-multiline.svg
+++ b/tests/testthat/_snaps/hgraph/custom-ellipses-multiline.svg
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='215.76,492.16 215.07,484.97 212.99,477.89 209.58,471.03 204.86,464.49 198.92,458.37 191.85,452.76 183.76,447.75 174.76,443.41 164.99,439.81 154.60,437.01 143.75,435.04 132.61,433.93 121.34,433.71 110.11,434.37 99.09,435.92 88.45,438.31 78.36,441.52 68.95,445.49 60.39,450.18 52.79,455.50 46.27,461.37 40.94,467.72 36.86,474.43 34.11,481.41 32.73,488.56 32.73,495.76 34.11,502.90 36.86,509.88 40.94,516.60 46.27,522.94 52.79,528.82 60.39,534.14 68.95,538.82 78.36,542.80 88.45,546.01 99.09,548.40 110.11,549.94 121.34,550.60 132.61,550.38 143.75,549.28 154.60,547.31 164.99,544.50 174.76,540.90 183.76,536.56 191.85,531.55 198.92,525.94 204.86,519.82 209.58,513.28 212.99,506.42 215.07,499.34 215.76,492.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #E69F00;' />
+<polygon points='522.03,101.15 521.34,93.96 519.26,86.88 515.84,80.02 511.13,73.48 505.19,67.36 498.12,61.75 490.03,56.74 481.03,52.40 471.26,48.80 460.87,46.00 450.02,44.03 438.88,42.92 427.61,42.70 416.38,43.36 405.36,44.90 394.72,47.30 384.62,50.51 375.22,54.48 366.66,59.17 359.06,64.49 352.54,70.36 347.21,76.71 343.13,83.42 340.38,90.40 339.00,97.55 339.00,104.75 340.38,111.89 343.13,118.87 347.21,125.59 352.54,131.93 359.06,137.81 366.66,143.13 375.22,147.81 384.62,151.79 394.72,155.00 405.36,157.39 416.38,158.93 427.61,159.59 438.88,159.37 450.02,158.27 460.87,156.30 471.26,153.49 481.03,149.89 490.03,145.55 498.12,140.54 505.19,134.93 511.13,128.81 515.84,122.27 519.26,115.41 521.34,108.33 522.03,101.15 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #56B4E9;' />
+<polygon points='648.89,394.40 648.20,387.22 646.12,380.14 642.71,373.28 637.99,366.74 632.05,360.62 624.98,355.01 616.89,350.00 607.89,345.66 598.12,342.06 587.73,339.25 576.88,337.28 565.74,336.18 554.47,335.96 543.24,336.62 532.22,338.16 521.58,340.56 511.49,343.76 502.08,347.74 493.52,352.43 485.92,357.75 479.40,363.62 474.07,369.96 469.99,376.68 467.24,383.66 465.86,390.81 465.86,398.00 467.24,405.15 469.99,412.13 474.07,418.84 479.40,425.19 485.92,431.06 493.52,436.38 502.08,441.07 511.49,445.05 521.58,448.25 532.22,450.65 543.24,452.19 554.47,452.85 565.74,452.63 576.88,451.53 587.73,449.56 598.12,446.75 607.89,443.15 616.89,438.81 624.98,433.80 632.05,428.19 637.99,422.07 642.71,415.53 646.12,408.67 648.20,401.59 648.89,394.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #56B4E9;' />
+<text x='124.16' y='473.45' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>H1:</text>
+<text x='124.16' y='498.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='90.18px' lengthAdjust='spacingAndGlyphs'> Long name</text>
+<text x='124.16' y='522.62' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00833</text>
+<text x='430.43' y='82.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>H2:</text>
+<text x='430.43' y='107.02' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='105.36px' lengthAdjust='spacingAndGlyphs'> Longer name</text>
+<text x='430.43' y='131.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00833</text>
+<text x='557.29' y='375.70' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='26.57px' lengthAdjust='spacingAndGlyphs'>H3:</text>
+<text x='557.29' y='400.28' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='112.96px' lengthAdjust='spacingAndGlyphs'> Longest name</text>
+<text x='557.29' y='424.86' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00833</text>
+<line x1='412.01' y1='158.61' x2='185.12' y2='448.27' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='186.69,437.21 185.12,448.27 195.48,444.10 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='481.54' y1='427.60' x2='215.76' y2='487.59' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='223.97,480.01 215.76,487.59 226.43,490.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='142.58' y1='434.70' x2='369.47' y2='145.03' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='367.90,156.09 369.47,145.03 359.10,149.20 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='510.74' y1='343.84' x2='431.13' y2='159.80' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='440.10,166.46 431.13,159.80 429.84,170.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='199.90' y1='458.96' x2='465.69' y2='398.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='457.48,406.56 465.69,398.98 455.02,395.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='476.97' y1='151.71' x2='556.59' y2='335.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='547.62,329.09 556.59,335.75 557.87,324.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='152.62' y='240.50' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='209.18' y='432.93' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='34.45' y='323.48' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='300.44' y='267.83' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='104.74' y='424.30' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='319.75' y='198.40' width='367.52' height='29.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='336.38' y='259.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='392.95' y='451.51' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='218.21' y='342.06' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='484.20' y='286.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='288.50' y='442.88' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='503.51' y='216.98' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='645.52' y='309.73' style='font-size: 15.00px; font-family: sans;' textLength='54.22px' lengthAdjust='spacingAndGlyphs'>Legend:</text>
+<rect x='646.23' y='317.47' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #E69F00;' />
+<rect x='646.23' y='334.75' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #56B4E9;' />
+<text x='668.28' y='330.57' style='font-size: 15.00px; font-family: sans;' textLength='54.21px' lengthAdjust='spacingAndGlyphs'>Group 1</text>
+<text x='668.28' y='347.85' style='font-size: 15.00px; font-family: sans;' textLength='54.21px' lengthAdjust='spacingAndGlyphs'>Group 2</text>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='142.34px' lengthAdjust='spacingAndGlyphs'>custom ellipses multiline</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/hgraph/gray-shades.svg
+++ b/tests/testthat/_snaps/hgraph/gray-shades.svg
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='178.90,106.02 178.35,98.24 176.69,90.57 173.96,83.14 170.20,76.05 165.45,69.42 159.81,63.34 153.34,57.91 146.15,53.21 138.35,49.31 130.06,46.27 121.39,44.14 112.49,42.94 103.49,42.70 94.52,43.42 85.72,45.09 77.23,47.68 69.17,51.16 61.66,55.47 54.82,60.54 48.75,66.30 43.55,72.67 39.28,79.54 36.03,86.82 33.83,94.38 32.73,102.12 32.73,109.92 33.83,117.66 36.03,125.23 39.28,132.50 43.55,139.37 48.75,145.74 54.82,151.50 61.66,156.58 69.17,160.89 77.23,164.36 85.72,166.95 94.52,168.62 103.49,169.34 112.49,169.10 121.39,167.91 130.06,165.77 138.35,162.73 146.15,158.83 153.34,154.13 159.81,148.70 165.45,142.62 170.20,135.99 173.96,128.91 176.69,121.47 178.35,113.81 178.90,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #808080;' />
+<polygon points='687.27,106.02 686.72,98.24 685.06,90.57 682.33,83.14 678.57,76.05 673.83,69.42 668.18,63.34 661.71,57.91 654.53,53.21 646.73,49.31 638.43,46.27 629.77,44.14 620.87,42.94 611.86,42.70 602.90,43.42 594.10,45.09 585.60,47.68 577.54,51.16 570.03,55.47 563.19,60.54 557.12,66.30 551.92,72.67 547.66,79.54 544.40,86.82 542.21,94.38 541.10,102.12 541.10,109.92 542.21,117.66 544.40,125.23 547.66,132.50 551.92,139.37 557.12,145.74 563.19,151.50 570.03,156.58 577.54,160.89 585.60,164.36 594.10,166.95 602.90,168.62 611.86,169.34 620.87,169.10 629.77,167.91 638.43,165.77 646.73,162.73 654.53,158.83 661.71,154.13 668.18,148.70 673.83,142.62 678.57,135.99 682.33,128.91 685.06,121.47 686.72,113.81 687.27,106.02 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #ABABAB;' />
+<polygon points='433.09,487.28 432.53,479.50 430.88,471.83 428.15,464.40 424.38,457.31 419.64,450.68 413.99,444.60 407.53,439.17 400.34,434.47 392.54,430.57 384.24,427.53 375.58,425.40 366.68,424.20 357.68,423.96 348.71,424.68 339.91,426.35 331.42,428.94 323.35,432.42 315.84,436.73 309.00,441.80 302.94,447.57 297.73,453.93 293.47,460.80 290.22,468.08 288.02,475.64 286.91,483.38 286.91,491.18 288.02,498.92 290.22,506.49 293.47,513.76 297.73,520.63 302.94,527.00 309.00,532.76 315.84,537.84 323.35,542.15 331.42,545.62 339.91,548.22 348.71,549.89 357.68,550.60 366.68,550.36 375.58,549.17 384.24,547.03 392.54,543.99 400.34,540.09 407.53,535.39 413.99,529.96 419.64,523.89 424.38,517.25 428.15,510.17 430.88,502.74 432.53,495.07 433.09,487.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #CCCCCC;' />
+<text x='105.74' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='105.74' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00833</text>
+<text x='614.12' y='99.60' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='614.12' y='124.19' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00833</text>
+<text x='359.93' y='480.87' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='359.93' y='505.45' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00833</text>
+<line x1='543.24' y1='122.47' x2='176.62' y2='122.47' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='186.30,116.88 176.62,122.47 186.30,128.05 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='308.05' y1='442.35' x2='124.74' y2='167.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='134.75,172.35 124.74,167.40 125.46,178.55 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='176.62' y1='89.57' x2='543.24' y2='89.57' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='533.56,95.16 543.24,89.57 533.56,83.99 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='378.92' y1='425.90' x2='562.23' y2='150.95' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='561.51,162.10 562.23,150.95 552.21,155.91 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='157.63' y1='150.95' x2='340.94' y2='425.90' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='330.92,420.95 340.94,425.90 340.22,414.75 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='595.13' y1='167.40' x2='411.82' y2='442.35' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='412.54,431.20 411.82,442.35 421.83,437.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='406.36' y='112.94' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='232.27' y='341.17' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='284.15' y='80.04' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='425.35' y='324.72' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='204.06' y='233.07' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='519.35' y='249.52' width='29.35' height='19.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='421.03' y='126.38' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='246.94' y='354.62' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='298.83' y='93.49' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='440.03' y='338.17' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='218.73' y='246.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='534.02' y='262.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='71.93px' lengthAdjust='spacingAndGlyphs'>gray shades</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/hgraph/hue-palette.svg
+++ b/tests/testthat/_snaps/hgraph/hue-palette.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
+    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
+<polygon points='203.20,108.86 202.55,100.73 200.62,92.72 197.43,84.95 193.04,77.55 187.51,70.62 180.93,64.27 173.39,58.59 165.01,53.68 155.91,49.61 146.24,46.43 136.13,44.20 125.75,42.95 115.25,42.70 104.79,43.45 94.53,45.19 84.63,47.90 75.22,51.54 66.47,56.04 58.49,61.34 51.41,67.36 45.34,74.02 40.37,81.20 36.58,88.79 34.02,96.70 32.73,104.79 32.73,112.94 34.02,121.02 36.58,128.93 40.37,136.53 45.34,143.71 51.41,150.36 58.49,156.38 66.47,161.69 75.22,166.19 84.63,169.82 94.53,172.53 104.79,174.27 115.25,175.02 125.75,174.77 136.13,173.52 146.24,171.29 155.91,168.12 165.01,164.04 173.39,159.13 180.93,153.46 187.51,147.11 193.04,140.18 197.43,132.77 200.62,125.01 202.55,117.00 203.20,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #FF9289;' />
+<polygon points='687.27,108.86 686.63,100.73 684.70,92.72 681.51,84.95 677.12,77.55 671.59,70.62 665.01,64.27 657.47,58.59 649.08,53.68 639.99,49.61 630.31,46.43 620.21,44.20 609.83,42.95 599.33,42.70 588.87,43.45 578.61,45.19 568.70,47.90 559.30,51.54 550.54,56.04 542.57,61.34 535.49,67.36 529.42,74.02 524.45,81.20 520.66,88.79 518.09,96.70 516.80,104.79 516.80,112.94 518.09,121.02 520.66,128.93 524.45,136.53 529.42,143.71 535.49,150.36 542.57,156.38 550.54,161.69 559.30,166.19 568.70,169.82 578.61,172.53 588.87,174.27 599.33,175.02 609.83,174.77 620.21,173.52 630.31,171.29 639.99,168.12 649.08,164.04 657.47,159.13 665.01,153.46 671.59,147.11 677.12,140.18 681.51,132.77 684.70,125.01 686.63,117.00 687.27,108.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #96CA00;' />
+<polygon points='687.27,484.44 686.63,476.31 684.70,468.30 681.51,460.53 677.12,453.13 671.59,446.20 665.01,439.85 657.47,434.17 649.08,429.26 639.99,425.19 630.31,422.01 620.21,419.78 609.83,418.53 599.33,418.28 588.87,419.03 578.61,420.78 568.70,423.48 559.30,427.12 550.54,431.62 542.57,436.92 535.49,442.94 529.42,449.60 524.45,456.78 520.66,464.38 518.09,472.28 516.80,480.37 516.80,488.52 518.09,496.61 520.66,504.51 524.45,512.11 529.42,519.29 535.49,525.94 542.57,531.96 550.54,537.27 559.30,541.77 568.70,545.40 578.61,548.11 588.87,549.85 599.33,550.60 609.83,550.35 620.21,549.10 630.31,546.87 639.99,543.70 649.08,539.62 657.47,534.71 665.01,529.04 671.59,522.69 677.12,515.76 681.51,508.35 684.70,500.59 686.63,492.58 687.27,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #00DAE0;' />
+<polygon points='203.20,484.44 202.55,476.31 200.62,468.30 197.43,460.53 193.04,453.13 187.51,446.20 180.93,439.85 173.39,434.17 165.01,429.26 155.91,425.19 146.24,422.01 136.13,419.78 125.75,418.53 115.25,418.28 104.79,419.03 94.53,420.78 84.63,423.48 75.22,427.12 66.47,431.62 58.49,436.92 51.41,442.94 45.34,449.60 40.37,456.78 36.58,464.38 34.02,472.28 32.73,480.37 32.73,488.52 34.02,496.61 36.58,504.51 40.37,512.11 45.34,519.29 51.41,525.94 58.49,531.96 66.47,537.27 75.22,541.77 84.63,545.40 94.53,548.11 104.79,549.85 115.25,550.60 125.75,550.35 136.13,549.10 146.24,546.87 155.91,543.70 165.01,539.62 173.39,534.71 180.93,529.04 187.51,522.69 193.04,515.76 197.43,508.35 200.62,500.59 202.55,492.58 203.20,484.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #E199FF;' />
+<text x='117.88' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H1</text>
+<text x='117.88' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<text x='601.96' y='102.44' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H2</text>
+<text x='601.96' y='127.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<text x='601.96' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H3</text>
+<text x='601.96' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<text x='117.88' y='478.03' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='21.83px' lengthAdjust='spacingAndGlyphs'>H4</text>
+<text x='117.88' y='502.61' text-anchor='middle' style='font-size: 17.07px; font-family: sans;' textLength='81.56px' lengthAdjust='spacingAndGlyphs'>α=0.00625</text>
+<line x1='530.81' y1='447.56' x2='165.42' y2='164.07' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='176.49,165.58 165.42,164.07 169.64,174.41 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='101.19' y1='419.32' x2='101.19' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='106.77,183.66 101.19,173.98 95.60,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='121.81' x2='201.81' y2='121.81' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,116.23 201.81,121.81 211.49,127.40 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='201.81' y1='95.91' x2='518.03' y2='95.91' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,101.50 518.03,95.91 508.35,90.32 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='585.26' y1='419.32' x2='585.26' y2='173.98' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='590.85,183.66 585.26,173.98 579.68,183.66 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='165.42' y1='429.24' x2='530.81' y2='145.75' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='526.58,156.09 530.81,145.75 519.74,147.27 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='189.03' y1='145.75' x2='554.42' y2='429.24' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='543.35,427.72 554.42,429.24 550.19,418.89 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='201.81' y1='471.49' x2='518.03' y2='471.49' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='508.35,477.08 518.03,471.49 508.35,465.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='618.65' y1='173.98' x2='618.65' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='613.07,409.65 618.65,419.32 624.24,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='134.58' y1='173.98' x2='134.58' y2='419.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='128.99,409.65 134.58,419.32 140.16,409.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='554.42' y1='164.07' x2='189.03' y2='447.56' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='193.25,437.21 189.03,447.56 200.10,446.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='518.03' y1='497.40' x2='201.81' y2='497.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='211.49,491.81 201.81,497.40 211.49,502.98 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='391.90' y='343.10' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='84.07' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='111.86' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='290.10' y='85.95' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='568.15' y='327.58' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='270.10' y='324.78' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='293.71' y='230.29' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='290.10' y='461.53' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='601.54' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='117.46' y='245.80' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='415.51' y='248.60' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<rect x='395.51' y='487.44' width='34.23' height='19.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<text x='409.01' y='356.98' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='101.19' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='125.73' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='307.22' y='99.82' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='585.26' y='341.46' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='287.22' y='338.66' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='310.83' y='244.16' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='307.22' y='475.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='618.65' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='134.58' y='259.68' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='432.62' y='262.48' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+<text x='412.62' y='501.31' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>0.33</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='0.00' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='65.32px' lengthAdjust='spacingAndGlyphs'>hue palette</text>
+</g>
+</svg>

--- a/tests/testthat/test-hgraph.R
+++ b/tests/testthat/test-hgraph.R
@@ -1,13 +1,61 @@
-test_that("Testing cases for multiplicity graphs with ggplot2", {
-  hGraph(6)
+testthat::test_that("hGraph: Basic graph layout", {
+  x <- hGraph()
+  vdiffr::expect_doppelganger("basic layout", x)
+})
 
-  cbPalette <- c("#999999", "#E69F00", "#56B4E9", "#009E73",
-                 "#F0E442", "#0072B2", "#D55E00", "#CC79A7")
-  hGraph(6,fill=as.factor(1:6),palette=cbPalette)
+testthat::test_that("hGraph: Note clockwise ordering", {
+  x <- hGraph(5)
+  vdiffr::expect_doppelganger("clockwise order", x)
+})
 
-  hGraph(3,x=sqrt(0:2),y=c(1,3,1.5),size=6,halfWid=.3,halfHgt=.3, trhw=0.6,
-         palette=cbPalette[2:4], fill = c(1, 2, 2),
-         legend.position = c(.6,.5), legend.name = "Legend:", labels = c("Group 1", "Group 2"),
-         nameHypotheses=c("H1:\n Long name","H2:\n Longer name","H3:\n Longest name"))
+testthat::test_that("hGraph: Add colors (default is 3 gray shades)", {
+  x <- hGraph(3, fill = 1:3)
+  vdiffr::expect_doppelganger("gray shades", x)
+})
 
+testthat::test_that("hGraph: Use a hue palette", {
+  x <- hGraph(4, fill = factor(1:4), palette = scales::hue_pal(l = 75)(4))
+  vdiffr::expect_doppelganger("hue palette", x)
+})
+
+testthat::test_that("hGraph: Different alpha allocation, hypotheses names, and transitions", {
+  alphaHypotheses <- c(.005, .007, .013)
+  nameHypotheses <- c("ORR", "PFS", "OS")
+  m <- matrix(c(
+    0, 1, 0,
+    0, 0, 1,
+    1, 0, 0
+  ), nrow = 3, byrow = TRUE)
+  x <- hGraph(3, alphaHypotheses = alphaHypotheses, nameHypotheses = nameHypotheses, m = m)
+
+  vdiffr::expect_doppelganger("alpha allocation hypotheses names transitions", x)
+})
+
+# Custom position and size of ellipses, change text to multi-line text
+# Adjust box width
+# add legend in middle of plot
+testthat::test_that("hGraph: Custom position and size of ellipses, change text to multi-line text", {
+  cbPalette <- c(
+    "#999999", "#E69F00", "#56B4E9", "#009E73",
+    "#F0E442", "#0072B2", "#D55E00", "#CC79A7"
+  )
+  x <- hGraph(3,
+    x = sqrt(0:2), y = c(1, 3, 1.5), size = 6, halfWid = .3,
+    halfHgt = .3, trhw = 0.6,
+    palette = cbPalette[2:4], fill = c(1, 2, 2),
+    legend.position = c(.95, .45), legend.name = "Legend:",
+    labels = c("Group 1", "Group 2"),
+    nameHypotheses = c("H1:\n Long name", "H2:\n Longer name", "H3:\n Longest name")
+  )
+
+  vdiffr::expect_doppelganger("custom ellipses multiline", x)
+})
+
+testthat::test_that("hGraph: Number of digits to show for alphaHypotheses", {
+  x <- hGraph(
+    nHypotheses = 3, size = 5, halfWid = 1.25, trhw = 0.25,
+    radianStart = pi / 2, offset = pi / 20, arrowsize = .03, digits = 3
+  )
+
+  vdiffr::expect_doppelganger("alpha digits", x)
 })


### PR DESCRIPTION
This PR ports over the visual regression tests for `hGraph()` from gsDesign. vdiffr is added as a soft dependency.

Following conventions, `tests/testthat/_snaps/` is added to `.Rbuildignore` so these tests will always pass on CRAN.

Note that tests requiring `stat_ellipse()` to run will need MASS as an explicit dependency under ggplot2 >= 4.0.0 (tidyverse/ggplot2#6578). Since MASS is already in `Imports` of this package, it won't be a problem here.