### PR TITLE
Include snapshot files in built package to satisfy testthat >= 3.3.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,4 +8,3 @@
 ^\.github$
 ^cran-comments\.md$
 ^docs$
-tests/testthat/_snaps$

--- a/tests/testthat/_snaps/hgraph/alpha-allocation-hypotheses-names-transitions.svg
+++ b/tests/testthat/_snaps/hgraph/alpha-allocation-hypotheses-names-transitions.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/hgraph/alpha-digits.svg
+++ b/tests/testthat/_snaps/hgraph/alpha-digits.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/hgraph/basic-layout.svg
+++ b/tests/testthat/_snaps/hgraph/basic-layout.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/hgraph/clockwise-order.svg
+++ b/tests/testthat/_snaps/hgraph/clockwise-order.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/hgraph/custom-ellipses-multiline.svg
+++ b/tests/testthat/_snaps/hgraph/custom-ellipses-multiline.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/hgraph/gray-shades.svg
+++ b/tests/testthat/_snaps/hgraph/gray-shades.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/hgraph/hue-palette.svg
+++ b/tests/testthat/_snaps/hgraph/hue-palette.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>


### PR DESCRIPTION
Similar to https://github.com/keaven/gsDesign/pull/227

This PR removes the `tests/testthat/_snaps$` rule from `.Rbuildignore` so the snapshot files will be included in the built package.

[testthat 3.3.0](https://tidyverse.org/blog/2025/11/testthat-3-3-0/) has made many changes on the snapshot testing behavior, which makes not detecting the snapshot files in the built package **in CI environments** a test fail instead of a pass:

> Additionally, `expect_snapshot()` and friends will now fail when creating a new snapshot on CI, as that's usually a signal that you've forgotten to run the snapshot code locally before committing.