### PR TITLE
Add workflow_dispatch to manually trigger GitHub Actions workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
It is convenient to be able to manually trigger a GitHub Actions workflow from any branch. In this case, I had wanted to test the new `CODECOV_TOKEN` I just defined for #41.